### PR TITLE
Add FIRMWARE, FIRMATA

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,10 +166,10 @@ The format of this glossary is modeled after [HugoGiraudel/SJSJ](https://github.
     unit for measuring electrical capacitance, named after physicist Michael Faraday
 * FET:
 * Field-effect transitor (FET):
-* **[Firmware](glossary/FIRMWARE.md)**<a name="firmware"></a>:
-    software written to the non-volatile [ROM](#rom) of embedded hardware
-* **Firmata**:
-    protocol for communication between the software on a host computer and a microcontroller; the best-known implementation is for Arduino
+* **[Firmware](glossary/FIRMWARE.md)** <a name="firmware"></a>:
+    semi-permanent software written to the non-volatile [ROM](#rom) of embedded hardware
+* **[Firmata](glossary/FIRMATA.md)** <a name="firmata"></a>:
+    protocol for communication between the software on a host computer and a microcontroller; the best-known implementation is for _[Arduino-compatible](#arduino-compatible)_ boards
 * **Flash** (noun) <a name="flash-noun"></a>:
     electronic non-volatile computer storage (_[EEPROM](#eeprom)_) medium that can be electrically erased and reprogrammed
 * Flash (verb):

--- a/README.md
+++ b/README.md
@@ -168,7 +168,8 @@ The format of this glossary is modeled after [HugoGiraudel/SJSJ](https://github.
 * Field-effect transitor (FET):
 * **[Firmware](glossary/FIRMWARE.md)**<a name="firmware"></a>:
     software written to the non-volatile [ROM](#rom) of embedded hardware
-* Firmata:
+* **Firmata**:
+    protocol for communication between the software on a host computer and a microcontroller; the best-known implementation is for Arduino
 * **Flash** (noun) <a name="flash-noun"></a>:
     electronic non-volatile computer storage (_[EEPROM](#eeprom)_) medium that can be electrically erased and reprogrammed
 * Flash (verb):

--- a/README.md
+++ b/README.md
@@ -166,7 +166,8 @@ The format of this glossary is modeled after [HugoGiraudel/SJSJ](https://github.
     unit for measuring electrical capacitance, named after physicist Michael Faraday
 * FET:
 * Field-effect transitor (FET):
-* Firmware:
+* **[Firmware](glossary/FIRMWARE.md)**<a name="firmware"></a>:
+    software written to the non-volatile [ROM](#rom) of embedded hardware
 * Firmata:
 * **Flash** (noun) <a name="flash-noun"></a>:
     electronic non-volatile computer storage (_[EEPROM](#eeprom)_) medium that can be electrically erased and reprogrammed
@@ -182,7 +183,7 @@ The format of this glossary is modeled after [HugoGiraudel/SJSJ](https://github.
 * GND:
 * **General Purpose I/O (GPIO)**<a name="general-purpose-io"></a>:
     general purpose pins that can be configured to perform input or output
-* **Genuino**: 
+* **Genuino**:
     [Arduino](#arduino-platform)'s sister-brand sold outside of the US due to trademark disputes
 * **GPIO**:
     _See [General Purpose I/O](#general-purpose-io)_

--- a/README.md
+++ b/README.md
@@ -54,20 +54,20 @@ The format of this glossary is modeled after [HugoGiraudel/SJSJ](https://github.
     device that can perform _[analog-to-digital conversion](#analog-to-digital-conversion)_
 * **[Anode](glossary/ANODE.md)**:
     electrode through which _[conventional current](#conventional-current)_ enters (flows into) a polarized device
+* **Arduino (platform)**<a name="arduino-platform"></a>:
+    open-source electronics platform based on easy-to-use hardware and software, intended for anyone making interactive projects and prototyping products
+* **Arduino (programming language)**:
+    any C or C++ that _[avr-gcc](#avr-gcc)_ can compile
+* **Arduino Compatible**<a name="arduino-compatible"></a>:
+    microcontrollors and development boards that can be programmed by the [Arduino IDE](#arduino-ide)
+* **Arduino IDE**<a name="arduino-ide"></a>:
+    development environment for writing in the Arduino programming language and uploading sketches to Arduino devices
 * **[ARM (company)](glossary/ARM-COMPANY.md)**:
     British semiconductor company that licenses the _[ARM architecture](#ARM-architecture)_
 * **ARM (architecture)**<a name="ARM-architecture"></a>:
     family of RISC-based architectures for power-optimized processors, well-suited for (among other things) embedded applications
 * **ARM Cortex M**:
     family of 32-bit RISC _[ARM](#ARM-architecture)_ processors widely used in embedded systems
-* **Arduino (platform)**<a name="arduino-platform"></a>:
-    open-source electronics platform based on easy-to-use hardware and software, intended for anyone making interactive projects and prototyping products
-* **Arduino Compatible**:
-    microcontrollors and development boards that can be programmed by the [Arduino IDE](#arduino-ide)
-* **Arduino IDE**<a name="arduino-ide"></a>:
-    development environment for writing in the Arduino programming language and uploading sketches to Arduino devices
-* **Arduino (programming language)**:
-    any C or C++ that _[avr-gcc](#avr-gcc)_ can compile
 * **Atmel Corporation**<a name="atmel-corporation"></a>:
     American semiconductor manufacturer, known for embedded microcontrollers including _[AVR](#avr)_ _[ATmega](#atmega)_ microcontrollers
 * **ATmega**, or _megaAVR_ <a name="atmega"></a>:

--- a/glossary/FIRMATA.md
+++ b/glossary/FIRMATA.md
@@ -1,11 +1,36 @@
-[**Firmata**](https://github.com/firmata/protocol) is a defined _protocol_ for communicating between a host computer's software and a microcontroller. It is based on the MIDI messaging format. It makes it possible to write logic for microcontrollers using higher-level languages.
+[**Firmata**](https://github.com/firmata/protocol) is a _protocol_ based on the MIDI messaging format. Firmata enables communication between software on a host computer and the microcontroller embedded in a hardware project, making it possible to write software logic for microcontrollers using diverse, higher-level languages.
 
-Its most complete and well-known _implementation_ of firmata is for Arduino-compatible boards ([firmata/arduino](https://github.com/firmata/arduino)).
+The use of firmata involves a host-client model of hardware development: a host computer runs software and communicates instructions to the microcontroller (or other processor), which behaves as a client. To accomplish this, both the software on the host computer and the firmware on the hardware need to "speak" (i.e. implement) firmata.
+
+## Firmata Implementations
+
+Firmata itself is a protocol and is _implemented_ for different platforms. The most popular implementation of firmata is for Arduino-compatible boards ([firmata/arduino](https://github.com/firmata/arduino)).
+
+## Libraries for Firmata Implementations
 
 The Arduino _implementation_ of _firmata_ in turn has numerous _libraries_ for different programming languages. Libraries are available for Java, JavaScript, PHP, ruby, python, etc.
 
+_Example_: [firmata.js](https://github.com/jgautier/firmata) is a JavaScript library for the Arduino implementaion of firmata.
+
+## Adapters
+
 Finally, some frameworks implement _adapters_ to language-specific _libraries_.
 
-[`cylon-firmata`](https://github.com/hybridgroup/cylon-firmata) is an _adapter_ between the [`cylon.js`](http://cylonjs.com/) framework and the _[Firmata.js](https://github.com/jgautier/firmata)_ JavaScript _library_ for the [Arduino _implementation_](https://github.com/firmata/arduino) of the [firmata _protocol_](https://github.com/firmata/protocol). Whew!
+## Firmata Software: All Together Now
 
-The popular [`johnny-five`](https://github.com/rwaldron/johnny-five) Node.js framework is also built on top of `firmata.js`.
+1. The _firmata_ protocol
+2. An _implementation_ of the firmata protocol for a platform (e.g. Arduino firmata)
+3. A language-specific _library_ for an implementation (e.g. firmata.js)
+4. (Sometimes) _adapters_ between software frameworks and _libraries_ (e.g. `cylon-firmata`)
+
+_Example_: [`cylon-firmata`](https://github.com/hybridgroup/cylon-firmata) is an _adapter_ between the [`cylon.js`](http://cylonjs.com/) framework and the _[Firmata.js](https://github.com/jgautier/firmata)_ JavaScript _library_ for the [Arduino _implementation_](https://github.com/firmata/arduino) of the [firmata _protocol_](https://github.com/firmata/protocol). Whew!
+
+*Note*: The popular [`johnny-five`](https://github.com/rwaldron/johnny-five) Node.js framework is also built on top of `firmata.js`.
+
+## Firmata Firmware
+
+To prepare hardware to be firmata-compatible, the microcontroller (or other processor) is flashed with _firmware_ that implements the firmata protocol.
+
+For example, you can use the Arduino IDE to _flash_ (upload) firmata firmware to an Arduino's microcontroller. In fact, several different firmata _sketches_ come pre-packaged with the Arduino IDE.
+
+Now both ends (software and hardware) are ready to communicate using the firmata protocol.

--- a/glossary/FIRMATA.md
+++ b/glossary/FIRMATA.md
@@ -1,0 +1,11 @@
+[**Firmata**](https://github.com/firmata/protocol) is a defined _protocol_ for communicating between a host computer's software and a microcontroller. It is based on the MIDI messaging format. It makes it possible to write logic for microcontrollers using higher-level languages.
+
+Its most complete and well-known _implementation_ of firmata is for Arduino-compatible boards ([firmata/arduino](https://github.com/firmata/arduino)).
+
+The Arduino _implementation_ of _firmata_ in turn has numerous _libraries_ for different programming languages. Libraries are available for Java, JavaScript, PHP, ruby, python, etc.
+
+Finally, some frameworks implement _adapters_ to language-specific _libraries_.
+
+[`cylon-firmata`](https://github.com/hybridgroup/cylon-firmata) is an _adapter_ between the [`cylon.js`](http://cylonjs.com/) framework and the _[Firmata.js](https://github.com/jgautier/firmata)_ JavaScript _library_ for the [Arduino _implementation_](https://github.com/firmata/arduino) of the [firmata _protocol_](https://github.com/firmata/protocol). Whew!
+
+The popular [`johnny-five`](https://github.com/rwaldron/johnny-five) Node.js framework is also built on top of `firmata.js`.

--- a/glossary/FIRMWARE.md
+++ b/glossary/FIRMWARE.md
@@ -1,0 +1,7 @@
+**Firmware**, sometimes called _embedded sofware_ is software that is written to the non-volatile program memory (ROM, often flash memory) of an embedded device. Firmware is _semi-permanent_, remaining in place unless replaced by updated firmware. Firmware is, in essence, software that sticks around in the hardware itself.
+
+Some embedded systems have firmware that is only programmed once. Take, for example, a microwave that has its microcontroller programmed with necessary firmware in the factory—it is never updated.
+
+Consumer electronic devices are increasingly capable of firmware updates. It is possible for consumers to update the firmware on many digital cameras, for instance. The process of writing or replacing (re-writing) firmware is known as _flashing_.
+
+Common consumer devices that rely on firmware include WiFi routers, personal computers (BIOS is firmware, e.g.), home appliances, automotive systems and media players.


### PR DESCRIPTION
This PR adds entries for FIRMWARE and FIRMATA.

FIRMATA is a...rather convoluted concept. The glossary entry added here is intended as a starting point, but it could certainly use some elaboration as we go.

I also re-alphabetized several items in the `Arduino` area. Opening a separate PR just for that seemed a bit...OCD; let me know if I should separate my concerns more carefully next time :).
